### PR TITLE
Remove log level setting

### DIFF
--- a/segment-appcues/src/main/java/com/appcues/segment/AppcuesDestination.kt
+++ b/segment-appcues/src/main/java/com/appcues/segment/AppcuesDestination.kt
@@ -34,7 +34,7 @@ class AppcuesDestination(private val context: Context) : DestinationPlugin(), An
             analytics.log("Appcues Destination is enabled")
             val appcuesSettings: AppcuesSettings? = settings.destinationSettings(key)
             if (appcuesSettings != null) {
-                appcues = Appcues.Builder(context, appcuesSettings.appcuesId, "").logging(Appcues.LoggingLevel.BASIC).build()
+                appcues = Appcues.Builder(context, appcuesSettings.appcuesId, "").build()
                 analytics.log("Appcues Destination loaded")
             }
         } else {


### PR DESCRIPTION
one-liner, accidentally left in from previous PR testing.

created https://app.shortcut.com/appcues/story/32026/segment-plugin-builder-options to more generally discuss how we should allow setting options on the Appcues SDK when using the plugin, based on convo started here https://github.com/appcues/segment-appcues-android/pull/1#discussion_r793991609