### PR TITLE
Update build dependencies for segment plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0"
+        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/samples/segment-destination-example/build.gradle
+++ b/samples/segment-destination-example/build.gradle
@@ -40,16 +40,16 @@ android {
 
 dependencies {
     // Segment
-    implementation 'com.segment.analytics.kotlin:android:1.4.2'
+    implementation 'com.segment.analytics.kotlin:android:1.7.0'
 
     // Segment-Appcues plugin
     implementation project(":segment-appcues")
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'com.google.android.material:material:1.6.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.2'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.4.2'
+    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.0'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.5.0'
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/segment-appcues/build.gradle
+++ b/segment-appcues/build.gradle
@@ -35,9 +35,9 @@ android {
 
 dependencies {
 
-    implementation 'com.segment.analytics.kotlin:android:1.4.2'
+    implementation 'com.segment.analytics.kotlin:android:1.7.0'
 
-    api 'com.appcues:appcues:1.0.0-beta04'
+    api 'com.appcues:appcues:1.0.0-beta+'
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/segment-appcues/segment-appcues.properties
+++ b/segment-appcues/segment-appcues.properties
@@ -1,6 +1,6 @@
 GROUP_ID = com.appcues
 ARTIFACT_ID = segment-appcues
-VERSION = 1.0.0-beta04
+VERSION = 1.0.0-beta05
 NAME = Segment-Appcues
 DESCRIPTION = Appcues device mode support for applications using Segment Analytics-Kotlin.
 ORG_ID = appcues


### PR DESCRIPTION
* Gradle 7.2.1 to match core SDK
* Kotlin 1.7.0 to match core SDK
* allow the version of the core SDK to match the latest beta without needing a plugin release - similar to what is being done on iOS per [convo here](https://github.com/appcues/segment-appcues-ios/pull/10#discussion_r912059024)