### PR TITLE
Updates for SDK 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ output.json
 /.idea/vcs.xml
 /.idea/workspace.xml
 /.idea/navEditor.xml
+/.idea/deploymentTargetDropDown.xml
+/.idea/assetWizardSettings.xml
 
 # Keystore files
 *.jks

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/samples/segment-destination-example/build.gradle
+++ b/samples/segment-destination-example/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.appcues.segment.examples.kotlin"
         minSdk 21
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -45,11 +45,11 @@ dependencies {
     // Segment-Appcues plugin
     implementation project(":segment-appcues")
 
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.0'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.5.0'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/segment-appcues/build.gradle
+++ b/segment-appcues/build.gradle
@@ -7,11 +7,11 @@ plugins {
 apply from: 'publish-maven.gradle'
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         minSdk 21
-        targetSdk 31
+        targetSdk 33
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -35,7 +35,7 @@ android {
 
 dependencies {
 
-    implementation 'com.segment.analytics.kotlin:android:1.7.0'
+    implementation 'com.segment.analytics.kotlin:android:1.9.1'
     api 'com.appcues:appcues:1.0.0'
 
     testImplementation 'junit:junit:4.13.2'

--- a/segment-appcues/build.gradle
+++ b/segment-appcues/build.gradle
@@ -36,7 +36,7 @@ android {
 dependencies {
 
     implementation 'com.segment.analytics.kotlin:android:1.9.1'
-    api 'com.appcues:appcues:1.0.0'
+    api 'com.appcues:appcues:1.1.0'
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/segment-appcues/src/main/java/com/appcues/segment/AppcuesDestination.kt
+++ b/segment-appcues/src/main/java/com/appcues/segment/AppcuesDestination.kt
@@ -69,14 +69,14 @@ class AppcuesDestination(
     }
 
     override fun track(payload: TrackEvent): BaseEvent {
-        if (payload.isAppcuesInternal.not()) {
+        if (payload.isValid) {
             appcues?.track(payload.event, payload.properties.mapToAppcues())
         }
         return payload
     }
 
     override fun screen(payload: ScreenEvent): BaseEvent {
-        if (payload.isAppcuesInternal.not()) {
+        if (payload.isValid) {
             appcues?.screen(payload.name, payload.properties.mapToAppcues())
         }
         return payload
@@ -99,11 +99,11 @@ class AppcuesDestination(
         return map
     }
 
-    private val TrackEvent.isAppcuesInternal: Boolean
-        get() = this.event.lowercase().startsWith(APPCUES_EVENT_PREFIX)
+    private val TrackEvent.isValid: Boolean
+        get() = this.event.isNotEmpty() && !this.event.lowercase().startsWith(APPCUES_EVENT_PREFIX)
 
-    private val ScreenEvent.isAppcuesInternal: Boolean
-        get() = this.name.lowercase().startsWith(APPCUES_EVENT_PREFIX)
+    private val ScreenEvent.isValid: Boolean
+        get() = this.name.isNotEmpty() && !this.name.lowercase().startsWith(APPCUES_EVENT_PREFIX)
 
     private val Any.isAllowedPropertyType: Boolean
         get() {


### PR DESCRIPTION
These are the updates to the Segment Plugin for Android to correspond with the native SDK 1.1 update that was just released.

* Update native SDK dependency version
* Add `_segmentVersion` auto property
* Improve logging and error handling
* Avoid re-ingesting internal `appcues:*` prefix events
* Bump sample app to compileSdk 33, some other sample app dependency version updates