### PR TITLE
⬆️  Update Appcues dependency version to 2.1.1

### DIFF
--- a/segment-appcues/build.gradle
+++ b/segment-appcues/build.gradle
@@ -37,7 +37,7 @@ android {
 dependencies {
 
     implementation 'com.segment.analytics.kotlin:android:1.10.1'
-    api 'com.appcues:appcues:2.1.0'
+    api 'com.appcues:appcues:2.1.1'
 
     testImplementation 'junit:junit:4.13.2'
 


### PR DESCRIPTION
updating sdk to 2.1.1 to include bug fix affecting Compose selectors for element-target.