### PR TITLE
Add Debug button in sample app

### DIFF
--- a/samples/segment-destination-example/src/main/java/com/appcues/segment/examples/kotlin/main/EventsFragment.kt
+++ b/samples/segment-destination-example/src/main/java/com/appcues/segment/examples/kotlin/main/EventsFragment.kt
@@ -2,10 +2,17 @@ package com.appcues.segment.examples.kotlin.main
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import com.appcues.segment.examples.kotlin.ExampleApplication
+import com.appcues.segment.examples.kotlin.R
 import com.appcues.segment.examples.kotlin.databinding.FragmentEventsBinding
 
 class EventsFragment : Fragment() {
@@ -34,6 +41,30 @@ class EventsFragment : Fragment() {
         }
 
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val menuHost: MenuHost = requireActivity()
+
+        menuHost.addMenuProvider(
+            object : MenuProvider {
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                    menuInflater.inflate(R.menu.events_menu, menu)
+                }
+
+                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                    return when (menuItem.itemId) {
+                        R.id.events_menu_debug -> {
+                            ExampleApplication.appcuesDestination.appcues?.debug(requireActivity())
+                            true
+                        }
+                        else -> false
+                    }
+                }
+            },
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
     }
 
     override fun onResume() {

--- a/samples/segment-destination-example/src/main/res/menu/events_menu.xml
+++ b/samples/segment-destination-example/src/main/res/menu/events_menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/events_menu_debug"
+        android:title="@string/events_menu_debug"
+        app:showAsAction="always" />
+</menu>

--- a/samples/segment-destination-example/src/main/res/values/strings.xml
+++ b/samples/segment-destination-example/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="save_button">save</string>
     <string name="group_label">Group</string>
     <string name="anonymous_user_button">Anonymous User</string>
+    <string name="events_menu_debug">Debug</string>
 </resources>


### PR DESCRIPTION
Noticed we didn't have our normal Debugger launch button in the sample app here, so copied that over real quick from the native SDK example.