### PR TITLE
Update maven publish plugin

### DIFF
--- a/segment-appcues/build.gradle
+++ b/segment-appcues/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.kotlin.plugin.serialization'
-    id "com.vanniktech.maven.publish" version "0.31.0"
+    id "com.vanniktech.maven.publish" version "0.32.0"
 }
 
 apply from: 'artifacts-android.gradle'


### PR DESCRIPTION
Update to 0.32 here matches the core SDK version and provides a more readable name in the publishing dashboard.

There is a newer 0.34 but that had some issues on first try and I don't have time to look into at the moment.